### PR TITLE
Add rateable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # FiveStar
 
 [![Build Status](https://travis-ci.org/rob-murray/five-star.svg?branch=master)](https://travis-ci.org/rob-murray/five-star)
-[![Code Climate](https://codeclimate.com/github/rob-murray/five-star.png)](https://codeclimate.com/github/rob-murray/five-star)
+[![Code Climate](https://codeclimate.com/github/rob-murray/five-star.svg)](https://codeclimate.com/github/rob-murray/five-star)
 [![Coverage Status](https://coveralls.io/repos/rob-murray/five-star/badge.svg?branch=master&service=github)](https://coveralls.io/github/rob-murray/five-star?branch=master)
-[![Dependency Status](https://gemnasium.com/rob-murray/five-star.svg)](https://gemnasium.com/rob-murray/five-star)
 [![Gem Version](https://badge.fury.io/rb/five-star.svg)](http://badge.fury.io/rb/five-star)
 
 
 :star: **FiveStar** :star: is a library to build a rating system - it allows you to rate *something* in your domain by various classification or criteria you define. This library gives you the structure to rate your object with as many of these different classifications as you like with the overall rating calculated from the weighted average.
 
-This uses Plain Old Ruby Objects so can be used in any project. Implement or use whatever persistence layer you want.
+This uses *Plain Old Ruby Objects* so can be used in any project.
 
-> Not sure if this is a gem or just a code design pattern :/
 
 ## Example
 

--- a/five-star.gemspec
+++ b/five-star.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "byebug" if RUBY_PLATFORM != 'java'
 end

--- a/lib/five-star/base_rater.rb
+++ b/lib/five-star/base_rater.rb
@@ -77,7 +77,7 @@ module FiveStar
     #
     # @api public
     def description
-      "#{self.class} rated #{rateable.class} at #{rating} with weighting of #{weighting}"
+      "#{self.class} rated #{rateable_name} at #{rating} with weighting of #{weighting}"
     end
 
     # Return the rating for the rater given to the `rateable` object.
@@ -148,6 +148,16 @@ module FiveStar
     # @api protected
     def min_rating
       0
+    end
+
+    # Return the name of the given rateable instance.
+    #
+    # @return [String]
+    #   the name of the object being rated.
+    #
+    # @api protected
+    def rateable_name
+      rateable.name
     end
   end
 end

--- a/lib/five-star/rateable.rb
+++ b/lib/five-star/rateable.rb
@@ -81,6 +81,18 @@ module FiveStar
       raters.map { |rater| rater.description }
     end
 
+    # The name of the object that is rateable. This may be used by raters
+    #   when generating descriptions.
+    # This can be overridden to provide a better response, otherwise is the class
+    #   name.
+    #
+    # @return [String] name of the class
+    #
+    # @api public
+    def name
+      self.class.name
+    end
+
     protected
 
     # The instance that included this module

--- a/spec/five-star/base_rater_spec.rb
+++ b/spec/five-star/base_rater_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe FiveStar::BaseRater do
+RSpec.describe FiveStar::BaseRater do
   let(:rateable) { double("Rateable", name: "Rateable") }
   subject { described_class.new(rateable) }
 

--- a/spec/five-star/base_rater_spec.rb
+++ b/spec/five-star/base_rater_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe FiveStar::BaseRater do
-  let(:rateable) { double("Rateable", class: "Rateable") }
+  let(:rateable) { double("Rateable", name: "Rateable") }
   subject { described_class.new(rateable) }
 
   describe ".build" do

--- a/spec/five-star/five_star_spec.rb
+++ b/spec/five-star/five_star_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe FiveStar do
+RSpec.describe FiveStar do
   describe ".rateable" do
     it "is the rateable module" do
       expect(FiveStar.rateable).to eq(FiveStar::Rateable)

--- a/spec/five-star/rateable_spec.rb
+++ b/spec/five-star/rateable_spec.rb
@@ -1,8 +1,9 @@
 require "spec_helper"
 
-describe FiveStar::Rateable do
+RSpec.describe FiveStar::Rateable do
   class Rater
     def self.build(_); self; end
+    def self.description; end
   end
 
   subject(:dummy_class) {

--- a/spec/five-star/rateable_spec.rb
+++ b/spec/five-star/rateable_spec.rb
@@ -45,31 +45,32 @@ describe FiveStar::Rateable do
   end
 
   describe "integration specs" do
-    class FirstRater
-      def self.build(_); self; end
-      def self.description; "A"; end
-      def self.rating; 2; end
-      def self.weighting; 0.6; end
+    class FirstRater < FiveStar.base_rater
+      def description; "A"; end
+      def rating; 2; end
+      def weighting; 0.6; end
     end
 
-    class SecondRater
-      def self.build(_); self; end
-      def self.description; "B"; end
-      def self.rating; 7; end
-      def self.weighting; 0.4; end
+    class SecondRater < FiveStar.base_rater
+      def rating; 7; end
+      def weighting; 0.4; end
     end
 
-    class ThirdRater
-      def self.build(_); self; end
-      def self.description; "C"; end
-      def self.rating; 6; end
-      def self.weighting; 0.3; end
+    class ThirdRater < FiveStar.base_rater
+      def description
+        "ThirdRater rated #{rateable.name} at #{rating} with weighting of #{weighting}"
+      end
+      def rating; 6; end
+      def weighting; 0.3; end
     end
 
     subject(:dummy_class) {
       Class.new do
         include FiveStar::Rateable
         rate_with(FirstRater, SecondRater, ThirdRater)
+        def name
+          "DummyClass"
+        end
       end
     }
 
@@ -81,7 +82,7 @@ describe FiveStar::Rateable do
 
     describe "#rating_descriptions" do
       it "returns descriptions from raters in order" do
-        expect(dummy_class.new.rating_descriptions).to eq ["A", "B", "C"]
+        expect(dummy_class.new.rating_descriptions).to eq ["A", "SecondRater rated DummyClass at 7 with weighting of 0.4", "ThirdRater rated DummyClass at 6 with weighting of 0.3"]
       end
     end
   end

--- a/spec/five-star/rating_calculator_spec.rb
+++ b/spec/five-star/rating_calculator_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe FiveStar::RatingCalculator do
+RSpec.describe FiveStar::RatingCalculator do
   let(:list_of_raters) { [first_rater, second_rater, third_rater] }
   subject { described_class.new(list_of_raters) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,9 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+begin
+  require "byebug"
+rescue LoadError
+  puts "Platform incompatible"
+end
 require "coveralls"
 require "codeclimate-test-reporter"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,27 @@ CodeClimate::TestReporter.start
 Coveralls.wear!
 
 require "five-star"
+
+#
+# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  config.disable_monkey_patching!
+  config.warnings = true
+  config.order = :random
+
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
Adds a method to `rateable` module for the name of the object defaulting to class name. This is then called in the *Rater* description instead of going straight for the class name - this gives the `rateable` class a chance to override and customise.